### PR TITLE
updated the app/ui/dashboard/nav-links.tsx file by importing the useP…

### DIFF
--- a/nextjs-dashboard/app/ui/dashboard/nav-links.tsx
+++ b/nextjs-dashboard/app/ui/dashboard/nav-links.tsx
@@ -1,8 +1,14 @@
+'use client'
+
 import {
   UserGroupIcon,
   HomeIcon,
   DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline';
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import clsx from 'clsx'
+
 
 // Map of links to display in the side navigation.
 // Depending on the size of the application, this would be stored in a database.
@@ -17,19 +23,25 @@ const links = [
 ];
 
 export default function NavLinks() {
+  const pathname = usePathname()
   return (
     <>
       {links.map((link) => {
         const LinkIcon = link.icon;
         return (
-          <a
+          <Link
             key={link.name}
             href={link.href}
-            className="flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3"
-          >
+            className={clsx("flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3", 
+              {
+                'bg-sky-100 text-blue-600': pathname === link.href
+              }
+            )  
+          }
+            >
             <LinkIcon className="w-6" />
             <p className="hidden md:block">{link.name}</p>
-          </a>
+          </Link>
         );
       })}
     </>


### PR DESCRIPTION
…athname hook from 'next/navigation', also imported Link from 'next/link', and clsx from 'clsx'. The Link component replaces the traditional a tag for linking between pages in th e application, the link tag allows navigation without refreshing the whole page, which the a tag cannot do. The usePathname hook allows me refrence the path in the url to the link, and then highlight which link is active, improving the UI/UX to let the user know which link/ page they are actually on in the moment. Finally I used clsx to actually toggle the css change highlighting the link that is active relative to the url path